### PR TITLE
added `mode/overlay.js` for gfm

### DIFF
--- a/package.js
+++ b/package.js
@@ -40,6 +40,10 @@ Package.onUse(function (api) {
 	api.add_files('lib/codemirror/addon/lint/javascript-lint.js', "client");
 
 
+	// overlay: required by `gfm.js`
+	api.add_files('lib/codemirror/addon/mode/overlay.js', "client");
+	
+	
 	// modes
 	api.add_files('lib/codemirror/mode/apl/apl.js', "client");
 	api.add_files('lib/codemirror/mode/asterisk/asterisk.js', "client");


### PR DESCRIPTION
Hi,

CodeMirror’s gfm (GitHub Flavored Markdown) mode requires `/addon/mode/overlay.js`, which wasn’t included in the `package.js` file. I’ve added the file and it works now.

Thanks for reviewing!