### PR TITLE
Fix error when removing editor.

### DIFF
--- a/lib/component/component.js
+++ b/lib/component/component.js
@@ -23,7 +23,7 @@ Template.CodeMirror.rendered = function() {
 };
 
 Template.CodeMirror.destroyed = function() {
-	this.$("textarea").parent().find(".CodeMirror").remove();
+	this.$("#" + (this.data.id || "code-mirror-textarea")).next('.CodeMirror').remove();
 }
 
 Template.CodeMirror.helpers({


### PR DESCRIPTION
Fixes an error that appears when there are multiple editors on the the same template, which results in removing all editors when destroying just one template instance.